### PR TITLE
Fix Logout problem, Add dialog when post uploaded

### DIFF
--- a/lib/pages/edit_profile.dart
+++ b/lib/pages/edit_profile.dart
@@ -107,7 +107,13 @@ class _EditProfileState extends State<EditProfile> {
 
   logout() async {
     await googleSignIn.signOut();
-    Navigator.push(context, MaterialPageRoute(builder: (context) => Home()));
+    Navigator.pushAndRemoveUntil(
+      context,
+      MaterialPageRoute(
+        builder: (BuildContext context) => Home(),
+      ),
+      (route) => false,
+    );
   }
 
   @override

--- a/lib/pages/upload.dart
+++ b/lib/pages/upload.dart
@@ -55,8 +55,6 @@ class _UploadState extends State<Upload>
       String location,
       String tag,
       String itemName}) {
-    print("post");
-    print(DateTime.now());
     postsRef
         .doc(widget.currentUser.id)
         .collection("userPosts")
@@ -119,6 +117,24 @@ class _UploadState extends State<Upload>
       description: captionController2.text,
       tag: captionController3.text,
       itemName: captionController1.text,
+    );
+    return showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        // return object of type Dialog
+        return AlertDialog(
+          title: new Text("Upload done"),
+          content: new Text("Your item is uploaded"),
+          actions: <Widget>[
+            new FlatButton(
+              child: new Text("Close"),
+              onPressed: () {
+                Navigator.pop(context);
+              },
+            ),
+          ],
+        );
+      },
     );
   }
 


### PR DESCRIPTION
## Pull Request 설명

수정한 것 2개(1개: notion task, 1개: 사용자 편리함을 위한 기능 추가)

1. Notion task  명: 로그아웃 할경우 뒤로 갈때 따른 사람 정보가 보이는 것
2. Post 업로드 완료 후, 완료 문구 뜨는 dialog 추가

**Notion task:**

- [x] :bug:Bug
- [ ] :tada:Feature
- [ ] :question:Other

Other를 고르셨으면 설명해주세요.

<br />

## 무엇이 변경 되었나요?
어떤 식으로 문제를 해결 하셨는지 설명해주세요.

1번
**(수정 전)** 로그아웃 후, 안드로이드 뒤로가기 버튼을 누르면, edit profile page가 다시 뜨는 현상이 발생했음.
**(수정 후)** 로그아웃 후, 뒤로가기 버튼을 누르면 어플이 꺼짐

2번
**(수정 전)** Post 업로드 시, 사진 찍고, 글 쓰고 post 누르면 upload 이미지가 떠서, 사용자가 느끼기에 포스트가 업로드 되었는지 알 수가 없음. 업로드가 된걸 확인하려면 profile 탭으로 이동해야했음
**(수정 후)** Post 업로드 완료 후, dialog를 통해 업로드가 완료 되었다는 문구를 표출
<br />

## 이 변경으로 인해 다른 개발자 분들이 특별히 주의 해야될 점 있나요?

없습니다.

<br />

## 테스팅을 하셨나요?
- [ ] 테스트 파일 추가
- [x] 어플 직접 사용
- [ ] 개인 코드 리뷰 (문법, 스타일링, 불필요한 주석, 등등...)

<br />

## 따로 기록 할게 있으시면 적어주세요.


<br />

마지막으로 Notion에 있는 task안에 댓글로 pull request 링크를 남겨주세요!:smiley::thumbsup:

<br />
<br />
